### PR TITLE
S4T dimensions

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -122,13 +122,18 @@
                 "inline": true
             },
             {
-                "name": "S4T External",
-                "value": "348mm x 225mm x 64mm",
-                "inline": false
+                "name": "S4T (standalone)",
+                "value": "200mm x 239mm x 69mm",
+                "inline": true
             },
             {
-                "name": "S4T Internal",
-                "value": "\\[pending\\]",
+                "name": "S4T-S (stacked, sandwich layout)",
+                "value": "200mm x 239mm x 134mm",
+                "inline": true
+            },
+            {
+                "name": "S4T-L (linked, vertical layout)",
+                "value": "400mm x 239mm x 69mm",
                 "inline": true
             },
             {


### PR DESCRIPTION
There is some conflicting info, but this is my approximation.

Sources:

https://store.nfc-systems.com/collections/cases/products/skyreach-4-tiny
>  External Dimensions
239mm x 200mm x 69mm

https://imgur.com/a/GFin4Df
> The S4T (Linked) fully assembled. (400x235x68mm)

https://imgur.com/a/kLiAdzc
No dimensions, just pictures.
